### PR TITLE
Add basic email checking tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,84 @@
-# Ministry of Justice Template Repository
+# Mail security checks
 
-Use this template to [create a repository] with the default initial files for a Ministry of Justice Github repository, including:
+This repo contains a set of small scripts to identify how well domains
+implement [email security controls](https://www.gov.uk/guidance/set-up-government-email-services-securely).
 
-* The correct LICENSE
-* Github actions
-* .gitignore file
+**These tools do not guarantee that the checked domains are compliant
+with the standards in question.** It only provides an indication that
+they _may_ support the standards.
 
-Once you have created your repository, please:
+Specifically, it provides tools to check for indications that the
+domain supports:
 
-* Edit the copy of this README.md file to document your project
-* Grant permissions to the appropriate MoJ teams
-* Setup branch protection
+- [TLS 1.2](https://www.gov.uk/government/publications/email-security-standards/transport-layer-security-tls)
+  (checks live support, but doesn't check for absence of lower versions
+  of TLS/SSL)
+- [TLS Reporting (TLS-RPT)](https://www.gov.uk/government/publications/email-security-standards/using-tls-reporting-tls-rpt-in-your-organisation)
+- [Mail Transfer Agent Strict Transport Security (MTA-STS)](https://www.digitalocean.com/community/tutorials/how-to-configure-mta-sts-and-tls-reporting-for-your-domain-using-apache-on-ubuntu-18-04)
+- [Domain-based Message Authentication, Reporting and Conformance
+  (DMARC)](https://www.gov.uk/government/publications/email-security-standards/domain-based-message-authentication-reporting-and-conformance-dmarc)
+- [Sender Policy Framework](https://www.gov.uk/government/publications/email-security-standards/sender-policy-framework-spf)
 
-[create a repository]: https://github.com/ministryofjustice/template-repository/generate
+It cannot check for [DomainKeys Identified Mail (DKIM)](https://www.gov.uk/government/publications/email-security-standards/domainkeys-identified-mail-dkim)
+because [DKIM verification](https://en.wikipedia.org/wiki/DomainKeys_Identified_Mail#Verification)
+depends on knowledge of message-specific parameters (notably, the
+"selector") to identify the domain to check for DKIM compliance.
+
+## Dependencies
+
+The tools in this repository depend on having
+[OpenSSL](https://www.openssl.org) and [GNU
+Coreutils](https://www.gnu.org/software/coreutils) (specifically,
+`timeout`) installed.
+
+On a Mac with [Homebrew](https://brew.sh), you can install these by running:
+
+```shell
+brew install openssl coreutils
+```
+
+## `check-domain-security` command
+
+The primary command is `check-domain-security`, which takes a single
+domain name and returns, in CSV format, the primary `MX` hostname, TLS
+connection response, and DNS values for TLS-RPT, SPF, DMARC, and MTA-STS:
+
+```shell
+$ check-domain-security digital.justice.gov.uk
+"digital.justice.gov.uk","aspmx.l.google.com.","221 2.0.0 closing connection m17si5212918wmg.68 - gsmtp","""v=TLSRPTv1;rua=mailto:tls-rua@mailcheck.service.ncsc.gov.uk""","""v=spf1 include:_spf.google.com include:mail.zendesk.com include:sendgrid.net include:amazonses.com include:spf.protection.outlook.com include:spf.messagelabs.com ip4:54.194.156.23 ~all""","""v=DMARC1;p=none;rua=mailto:dmarc-rua@dmarc.service.gov.uk,mailto:dmarc@digital.justice.gov.uk;""",""
+```
+
+The CSV response has the following columns:
+
+```csv
+Requested domain, Primary MX host, TLS connection response, TLS-RPT, SPF, DMARC, MTA-STS
+```
+
+To check a large number of domains, we recommend creating a text file
+containing one domain per line, and running the command using `xargs`
+as follows:
+
+```shell
+$ cat input-domains.txt \
+  | xargs -L1 -I{} check-domain-security {}
+```
+
+In this snippet, we read from `input-domains.txt`, then pipe (`|`) to
+`xargs`, which calls `check-domain-security` once per line (`-L1`) with
+the contents of the line as an argument (`-I{}` and `{}`).
+
+## Other commands
+
+`check-domain-security` uses a suite of other, smaller commands to
+gather its data. Each command takes a single domain as their only
+parameter. These are:
+
+- `check-dmarc`: Gets the target domain's DMARC DNS record.
+- `check-mta-sts`: Gets the target domain's MTA-STS DNS record. This
+  **does not check for a valid MTA-STS policy** file.
+- `check-spf`: Gets the target domain's SPF DNS record.
+- `check-tls-1-2`: Takes a mail server domain (use `get-mx-hosts` to
+  get this for your target domain) and attempts to open a TLS 1.2
+  connection to it.
+- `check-tls-rpt`: Gets the target domain's TLS-RPT record.
+- `get-mx-hosts`: Gets the target domain's MX hosts in priority order.

--- a/bin/check-dmarc
+++ b/bin/check-dmarc
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+dig +short _dmarc.$1 TXT

--- a/bin/check-dmarc
+++ b/bin/check-dmarc
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-dig +short _dmarc.$1 TXT
+dig +short "_dmarc.$1" TXT

--- a/bin/check-domain-security
+++ b/bin/check-domain-security
@@ -1,0 +1,34 @@
+#!/usr/bin/env sh
+
+escape_quotes() {
+  echo "${1//\"/\"\"}"
+}
+
+TLS_TIMEOUT=${TLS_TIMEOUT:=2s}
+
+RED='\033[0;31m'
+RESET_COLOR='\033[0m'
+
+# Check we have `timeout` installed
+if type "timeout" &> /dev/null ; then
+  timeout_cmd="timeout"
+elif type "gtimeout" &> /dev/null ; then
+  timeout_cmd="gtimeout"
+else
+  timeout_cmd=""
+  TLS_TIMEOUT=""
+  echo "${RED}No timeout command found; using openssl's default timeout${RESET_COLOR}"
+  echo "${RED}Consider installing coreutils to install timeout${RESET_COLOR}"
+fi
+
+mx_hosts=$(get-mx-hosts $1)
+mx_hosts=(${mx_hosts[@]})
+
+tls="$($timeout_cmd $TLS_TIMEOUT check-tls-1-2 ${mx_hosts[0]})"
+
+mta=$(escape_quotes "`check-mta-sts $1`")
+spf=$(escape_quotes "`check-spf $1`")
+tlsrpt=$(escape_quotes "`check-tls-rpt $1`")
+dmarc=$(escape_quotes "`check-dmarc $1`")
+
+echo "\"${1}\",\"${mx_hosts}\",\"${tls}\",\"${tlsrpt}\",\"${spf}\",\"${dmarc}\",\"${mta}\""

--- a/bin/check-domain-security
+++ b/bin/check-domain-security
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 escape_quotes() {
-  echo "${1//\"/\"\"}"
+  echo "$1" | sed "s/\"/\"\"/g"
 }
 
 TLS_TIMEOUT=${TLS_TIMEOUT:=2s}
@@ -9,10 +9,10 @@ TLS_TIMEOUT=${TLS_TIMEOUT:=2s}
 RED='\033[0;31m'
 RESET_COLOR='\033[0m'
 
-# Check we have `timeout` installed
-if type "timeout" &> /dev/null ; then
+# Check we have $(timeout) installed
+if type "timeout" > /dev/null 2>&1 ; then
   timeout_cmd="timeout"
-elif type "gtimeout" &> /dev/null ; then
+elif type "gtimeout" > /dev/null 2>&1 ; then
   timeout_cmd="gtimeout"
 else
   timeout_cmd=""
@@ -21,14 +21,13 @@ else
   echo "${RED}Consider installing coreutils to install timeout${RESET_COLOR}"
 fi
 
-mx_hosts=$(get-mx-hosts $1)
-mx_hosts=(${mx_hosts[@]})
+primary_mx=$(get-mx-hosts "$1" | head -n 1)
 
-tls="$($timeout_cmd $TLS_TIMEOUT check-tls-1-2 ${mx_hosts[0]})"
+tls="$("$timeout_cmd" "$TLS_TIMEOUT" check-tls-1-2 "${primary_mx}")"
 
-mta=$(escape_quotes "`check-mta-sts $1`")
-spf=$(escape_quotes "`check-spf $1`")
-tlsrpt=$(escape_quotes "`check-tls-rpt $1`")
-dmarc=$(escape_quotes "`check-dmarc $1`")
+mta=$(escape_quotes "$(check-mta-sts "$1")")
+spf=$(escape_quotes "$(check-spf "$1")")
+tlsrpt=$(escape_quotes "$(check-tls-rpt "$1")")
+dmarc=$(escape_quotes "$(check-dmarc "$1")")
 
-echo "\"${1}\",\"${mx_hosts}\",\"${tls}\",\"${tlsrpt}\",\"${spf}\",\"${dmarc}\",\"${mta}\""
+echo "\"${1}\",\"${primary_mx}\",\"${tls}\",\"${tlsrpt}\",\"${spf}\",\"${dmarc}\",\"${mta}\""

--- a/bin/check-mta-sts
+++ b/bin/check-mta-sts
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+dig +short _mta-sts.$1 TXT

--- a/bin/check-mta-sts
+++ b/bin/check-mta-sts
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-dig +short _mta-sts.$1 TXT
+dig +short "_mta-sts.$1" TXT

--- a/bin/check-spf
+++ b/bin/check-spf
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+dig +short $1 TXT | grep -i '^"v=spf'

--- a/bin/check-spf
+++ b/bin/check-spf
@@ -1,3 +1,4 @@
 #!/usr/bin/env sh
 
-dig +short $1 TXT | grep -i '^"v=spf'
+dig +short "$1" TXT |
+  grep -i '^"v=spf' # Only get the SPF record(s)

--- a/bin/check-tls-1-2
+++ b/bin/check-tls-1-2
@@ -1,10 +1,10 @@
 #!/usr/bin/env sh
 
-echo "QUIT" \ # Close the connection when it's established
-  | openssl s_client \
-      -starttls smtp \ # Connect as SMTP client
+echo "QUIT" | # Close the connection when it's established
+  openssl s_client \
+      -starttls smtp \
       -tls1_2 -crlf \
-      -quiet \ # Hide connection info
-      -connect $1:25 \
-      2>/dev/null \ # Hide more connection info
-  | tr -cd \"[:print:]\" # Strip unprintable characters
+      -quiet \
+      -connect "$1:25" \
+      2>/dev/null | # Hide more connection info
+  tr -cd "[:print:]" # Strip unprintable characters

--- a/bin/check-tls-1-2
+++ b/bin/check-tls-1-2
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+echo "QUIT" \ # Close the connection when it's established
+  | openssl s_client \
+      -starttls smtp \ # Connect as SMTP client
+      -tls1_2 -crlf \
+      -quiet \ # Hide connection info
+      -connect $1:25 \
+      2>/dev/null \ # Hide more connection info
+  | tr -cd \"[:print:]\" # Strip unprintable characters

--- a/bin/check-tls-rpt
+++ b/bin/check-tls-rpt
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-dig +short _smtp._tls.$1 TXT
+dig +short "_smtp._tls.$1" TXT

--- a/bin/check-tls-rpt
+++ b/bin/check-tls-rpt
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+dig +short _smtp._tls.$1 TXT

--- a/bin/get-mx-hosts
+++ b/bin/get-mx-hosts
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-dig +short $1 MX \
-  | sort --numeric-sort \
-  | cut -d' ' -f2  \ # Domain is in column 2
-  | tr '[:upper:]' '[:lower:]' # Lowercase everything for consistency
+dig +short "$1" MX |
+  sort --numeric-sort |
+  cut -d' ' -f2 | # Domain is in column 2
+  tr '[:upper:]' '[:lower:]' # Lowercase everything for consistency

--- a/bin/get-mx-hosts
+++ b/bin/get-mx-hosts
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+dig +short $1 MX \
+  | sort --numeric-sort \
+  | cut -d' ' -f2  \ # Domain is in column 2
+  | tr '[:upper:]' '[:lower:]' # Lowercase everything for consistency


### PR DESCRIPTION
This adds a set of small scripts that can be composed together to test if domains' [email settings follow government security guidance](https://www.gov.uk/guidance/set-up-government-email-services-securely).

They are all very small shell scripts that do one thing, and mostly exist to document the intent of each component.